### PR TITLE
Added a Package.json file for npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "ngradialgauge",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "angular": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.10.tgz",
+      "integrity": "sha512-PCZ5/hVdvPQiYyH0VwsPjrErPHRcITnaXxhksceOXgtJeesKHLA7KDu4X/yvcAi+1zdGgGF+9pDxkJvghXI9Wg=="
+    },
+    "d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/stherrienaspnet/ngRadialGauge#readme",
   "dependencies": {
-    "angular": "~1.3.0",
-    "d3": "~3.4.0"
+    "angular": "~1.6.3",
+    "d3": "~3.5.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "ngradialgauge",
+  "version": "1.0.0",
+  "description": "AngularJS Radial Gauge",
+  "main": "src/ng-radial-gauge-dir.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stherrienaspnet/ngRadialGauge.git"
+  },
+  "keywords": [
+    "AngularJS",
+    "Radial",
+    "Gauge",
+    "d3"
+  ],
+  "author": "Stephane Therrien",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/stherrienaspnet/ngRadialGauge/issues"
+  },
+  "homepage": "https://github.com/stherrienaspnet/ngRadialGauge#readme",
+  "dependencies": {
+    "angular": "~1.3.0",
+    "d3": "~3.4.0"
+  }
+}


### PR DESCRIPTION
This allows those not using bower to use this project using only npm. It will still need to be registered with npm in order for people to install using a command like 'npm install ngradialgauge', but it can be installed using the github url until then. Closes issue #24 